### PR TITLE
prevent failure if student is no longer enrolled in second semester

### DIFF
--- a/src/extract/ExtractForRegistration.py
+++ b/src/extract/ExtractForRegistration.py
@@ -146,6 +146,9 @@ class RegistrationCreator:
                 sycClass = sycClasses.loc[studentClassIndex]
                 sycClassDetails = sycClassesDetails.loc[studentClassIndex]
                 sycPrimaryStaffID = sycClass['PrimaryStaffID']
+                if sycPrimaryStaffID not in sycEmployees.index:
+                    continue
+                
                 sycPrimaryStaff = sycEmployees.loc[sycPrimaryStaffID]
                 registration['Class'] = Generators.createClassName(
                     class_name=sycStudentClass['Name'],


### PR DESCRIPTION
I noticed a failure when students are no longer enrolled / assigned a class after they finish DSD II/ year 2