### PR TITLE
improper regular expression string

### DIFF
--- a/src/extract/FilterAndProjectCSVFiles.py
+++ b/src/extract/FilterAndProjectCSVFiles.py
@@ -7,7 +7,7 @@ from pathlib import Path
 def get_table_name(file_path):
     # strip of pattern at end of file indicating date and time stamp,
     # e.g._11-12-2023-225308
-    p = re.compile('[a-zA-Z]([\w_]*[a-zA-Z])?')
+    p = re.compile(r'[a-zA-Z]([\w_]*[a-zA-Z])?')
     m = p.match(file_path.stem)
     return file_path.stem[:m.end()]
 


### PR DESCRIPTION
issue with regular expression string; should be raw string
occurred on Ubuntu on Windows 11 deployment with python 3.12.3